### PR TITLE
Fix About8 social links typecheck

### DIFF
--- a/src/components/about8.tsx
+++ b/src/components/about8.tsx
@@ -58,14 +58,13 @@ const About8 = ({ className }: About8Props) => {
             aria-label="Social links"
             className="flex flex-wrap justify-center gap-2 pt-1"
           >
-            {links.map(({ label, href, icon: Icon }) => (
+            {links.map(({ label, href }) => (
               <Button key={href} asChild variant="outline" size="sm">
                 <a
                   href={href}
                   target={href.startsWith("http") ? "_blank" : undefined}
                   rel={href.startsWith("http") ? "noreferrer" : undefined}
                 >
-                  {Icon && <Icon data-icon="inline-start" />}
                   {label}
                 </a>
               </Button>


### PR DESCRIPTION
## Summary
- remove the unused `icon` destructuring from `About8` social links
- keep the rendered social buttons unchanged
- restore a clean `astro check`

## Verification
- `pnpm astro check`